### PR TITLE
Suggestions for improvement of Kumodd

### DIFF
--- a/docs/guide/Default-configuration.md
+++ b/docs/guide/Default-configuration.md
@@ -37,6 +37,7 @@ gdrive:
     - [fullpath, 50]
     normal:
     - [name, 20]
+    - [originalFilename, 20]
     - [category, 4]
     - [status, 7]
     - [md5Match, 7]

--- a/modules/gdrive.py
+++ b/modules/gdrive.py
@@ -792,6 +792,10 @@ def walk_folders( ctx, folder, handle_item, path=None, cnt=0 ):
         'spaces': FLAGS.spaces,
         'pageSize': 1000,
     }
+
+    if "fullText contains" in param["q"]:
+        param.pop("orderBy")
+
     while True: # repeat for each page
         try:
             file_list = ctx.files.list(**param).execute()

--- a/modules/gdrive.py
+++ b/modules/gdrive.py
@@ -758,7 +758,7 @@ def get_query_from_filters():
     else:
         return None
 
-def walk_folders( ctx, folder, handle_item, path=None ):
+def walk_folders( ctx, folder, handle_item, path=None, cnt=0 ):
     if path is None:
         path = '.'
     query = f"'{folder['id']}' in parents"
@@ -792,9 +792,15 @@ def walk_folders( ctx, folder, handle_item, path=None ):
             break
         filename = folder['name'].replace( '/', '_' )
         for item in sorted(filter(is_file, file_list['files']), key=lambda i:i['name']):
-            handle_item( ctx, item, path )
+            if not cnt:
+                handle_item( ctx, item, '/' + filename )
+                continue
+            handle_item( ctx, item, path + '/' + filename )
         for item in sorted(filter(is_folder, file_list['files']), key=lambda i:i['name']):
-            walk_folders( ctx, item, handle_item, path + '/' + filename )
+            if not cnt:
+                walk_folders( ctx, item, handle_item, '/' + filename, cnt=cnt+1 )
+                continue
+            walk_folders( ctx, item, handle_item, path + '/' + filename, cnt=cnt+1 )
         if file_list.get('nextPageToken'):
             param['pageToken'] = file_list.get('nextPageToken')
         else:
@@ -818,7 +824,7 @@ def get_titles( config, metadata_names ):
 
 def get_gdrive_folder( ctx, path_in=None ):
     if path_in is None:
-        return ctx.files.get( fileId='root' ).execute(), '.'
+        return ctx.files.get( fileId='root' ).execute(), 'My Drive'
     file_id = 'root'
     path = 'My Drive'
     for folder_name in path_in.split('/'):

--- a/modules/gdrive.py
+++ b/modules/gdrive.py
@@ -863,12 +863,12 @@ def main(argv):
 
     if not os.path.exists(FLAGS.config):
         if FLAGS.config.find('/'):
-            ensure_dir(dirname(FLAGS.config[:FLAGS.config.rfind('/')]))
+            ensure_dir(dirname(FLAGS.config))
         # catch issues in the bundled config early by decoding and encoding
         yaml.dump(yaml.safe_load('''
 gdrive:
-  user_cred: google_drive_user_credentials.json
-  api_cred: google_api_credentials.json
+  user_cred: config/google_drive_user_credentials.json
+  api_cred: config/google_api_credentials.json
   csv_prefix: ./filelist-
   column_sets:
     short:

--- a/modules/gdrive.py
+++ b/modules/gdrive.py
@@ -242,24 +242,32 @@ def jsonpath_list( obj, object_path_list ):
 def supplement_drive_file_metadata(ctx, drive_file, path):
     drive_file['path'] = path
 
-    name = drive_file.get('originalFilename') or drive_file['name'].replace( '/', '_' )
+    name = drive_file.get('name') or drive_file['name'].replace( '/', '_' )
+    originalName = drive_file.get('originalFilename') or drive_file['name'].replace('/', '_')
+
     if drive_file['mimeType'].startswith('application/vnd.google'):
         extension = get_ext(drive_file, drive_file)
         if not drive_file.get('fileExtension') and extension:
             drive_file['fileExtension'] = extension
+        if not drive_file.get('name'):
+            drive_file['name'] = name
         if not drive_file.get('originalFilename'):
-            drive_file['originalFilename'] = name
+            drive_file['originalFilename'] = originalName
     else:
         if '.' in name:
             if not drive_file.get('fileExtension'):
                 drive_file['extension'] = name[name.rfind('.') + 1:]
+            if not drive_file.get('name'):
+                drive_file['name'] = name
             if not drive_file.get('originalFilename'):
-                drive_file['originalFilename'] = name
+                drive_file['originalFilename'] = originalName
         else:
             if not drive_file.get('fileExtension'):
                 drive_file['extension'] = ''
+            if not drive_file.get('name'):
+                drive_file['name'] = name
             if not drive_file.get('originalFilename'):
-                drive_file['originalFilename'] = name
+                drive_file['originalFilename'] = originalName
 
     drive_file['fullpath'] = drive_file['path'] + '/' + file_name(drive_file)
 
@@ -582,7 +590,7 @@ def local_data_dir( drive_file, username ):
     return '/'.join([ FLAGS.destination, username, drive_file['path'] ])
 
 def file_name( drive_file, revision=None ):
-    name = drive_file['originalFilename']
+    name = drive_file['name']
     if drive_file.get('fileExtension') and name.rfind('.' + drive_file['fileExtension']) > 0:
         name = name[0:name.rfind('.' + drive_file['fileExtension'])]
     if int(drive_file.get('version', 1)) > 1:
@@ -885,6 +893,7 @@ gdrive:
     - [fullpath, 50]
     normal:
     - [name, 20]
+    - [originalFilename, 20]
     - [category, 4]
     - [status, 7]
     - [md5Match, 7]


### PR DESCRIPTION
Hi,

We have been using your tool for a small university research project and found a few suggestions for improvement and bugs that we addressed. Below is a summary of these fixes:

## Crash if config/config.yml doesn't exist
The script does not run initially when running e.g. `kumodd -l all` since the `config/config.yml` does not yet exist. There is a bug in the existing application which attempts to create a folder from a variable which is `None`. The one-line fix needed to address this is made in commit 1227daa, line 866. In the same commit, we also modified the default path to the user- and API-credentials file to match those described in the existing documentation.

## Support both original filename and current filename
When running `kumodd -l all` and examining the resulting CSV-file we discovered that the original filename of uploaded files were shown instead of the current file name. Since we found this behaviour to be somewhat misleading we made modifications to make sure that, by default, both the original filename and the current filename is shown in the output. These were made in commits e19d312 and b598df6.

## Fix wrong fullpaths
Another issue was the generated paths for files when running `kumodd -l all`. Originally, all paths would start with “.” instead of the name “My Drive”, which is the default root directory of Google Drive. Furthermore, in the case of nested folders, the final folder would not be shown at all. This issue was due to a problem with the recursive function `walk_folders`, and was addressed in commit 35bef11.

## Download of unsupported filetypes
Some files, in particular Google Forms, cannot be downloaded using e.g. `kumodd -d all`, but would result in an infinite loop and 400 error. This was resolved by adding a maximum number of allowed retries, and was addressed in commit 0198e40.

## Issue with fullText query strings
The Google Drive API query strings do not support sorting using the `orderBy` parameter on full text queries. This was addressed in commit e3e0b66.

---

Thanks for developing a cool and useful tool! :)

Regards,
Emilia Dunfelt, Hannah Maiti, David Mattsson